### PR TITLE
Make headers on each page consistent by using h2 tags

### DIFF
--- a/module/Phph/Site/view/phph/contact/index.phtml
+++ b/module/Phph/Site/view/phph/contact/index.phtml
@@ -4,7 +4,7 @@ $this->headTitle($title);
 ?>
 
 <div class="fixed-width" id="content">
-    <h1><?php echo $title; ?></h1>
+    <h2><?php echo $title; ?></h2>
     <p>There are several ways to get in touch, but the best way is via our <a href="https://groups.google.com/group/phphants">Google Groups community</a>.</p>
     <p>Alternatively you will find us...</p>
     <ul>

--- a/module/Phph/Site/view/phph/join-us/index.phtml
+++ b/module/Phph/Site/view/phph/join-us/index.phtml
@@ -5,7 +5,7 @@ $this->headTitle($title);
 
 <div class="fixed-width" id="content">
     <a href="https://groups.google.com/group/phphants" id="google-groups-link"><img src="/images/google-groups-logo.png" alt="Google Groups" /></a>
-    <h1><?php echo $title; ?></h1>
+    <h2><?php echo $title; ?></h2>
     <p>PHP Hampshire costs nothing to join, and you can have any level of involvement in the group. Obviously if you want to help out and get stuck in and help out, we'll be more than happy, but it is not a requirement!</p>
 
     <p>Our discussions take place on our <strong><a href="https://groups.google.com/group/phphants">Google Group community</a></strong> which is a discussion mailing list and forum.</p>


### PR DESCRIPTION
Just noticed contact and join us pages were using `<h1>`s whereas the others were using `<h2>`s.
