### PR TITLE
Reworded the coc to be less confrontational

### DIFF
--- a/module/Phph/Site/view/phph/code-of-conduct/index.phtml
+++ b/module/Phph/Site/view/phph/code-of-conduct/index.phtml
@@ -19,15 +19,15 @@ div.content ul li {
     of conduct. Organisers will enforce this code throughout all events. We are expecting cooperation from all
     participants to help ensure a safe, inclusive environment for everybody.</p>
 
-    <p><strong><em>tl;dr: We operate a zero-tolerance policy on harassment. Don&#39;t be a jerk.</em></strong></p>
+    <p><strong><em>tl;dr: We operate a zero-tolerance policy on harassment. Keep it friendly.</em></strong></p>
 
     <p>Additionally, we expect you to:</p>
     <p>
         <ul>
             <li>Behave professionally.</li>
-            <li>Share and be nice.</li>
-            <li>Not insult or put down others experience or ability.</li>
             <li>Be respectful to others.</li>
+            <li>Not insult or put down others experience or ability.</li>
+            <li>Share and be nice.</li>
         </ul>
     </p>
 


### PR DESCRIPTION
As discussed, I'd like to be able to quote the tl;dr version for minor violations without sounding confrontational. 

To say "Keep it friendly" is less likely to offend than "Don't be a jerk" when picking someone up on a minor issue, especially where they weren't necessarily aware they were causing offence.