### PR TITLE
Rename sponsor logo CSS class so that adblock doesn't block it

### DIFF
--- a/module/Phph/Site/view/phph/sponsors/index.phtml
+++ b/module/Phph/Site/view/phph/sponsors/index.phtml
@@ -10,28 +10,28 @@ $this->headTitle($title);
 
     <ul class="sponsors">
         <li class="sponsor">
-            <a href="http://www.spectrumit.co.uk/"><img src="/images/spectrum-it.png" alt="Spectrum IT" class="sponsor-logo" /></a>
+            <a href="http://www.spectrumit.co.uk/"><img src="/images/spectrum-it.png" alt="Spectrum IT" class="spons-logo" /></a>
             <h2>Spectrum IT</h2>
             <p>Spectrum IT Recruitment is a collaboration of over 10 years recruitment experience, providing recruitment services and consultancy to the IT sector UK wide.</p>
             <p>Visit: <a href="http://www.spectrumit.co.uk/">www.spectrumit.co.uk</a></p>
         </li>            
 
         <li class="sponsor">
-            <a href="https://roave.com/"><img src="/images/roave.png" alt="Roave" class="sponsor-logo" /></a>
+            <a href="https://roave.com/"><img src="/images/roave.png" alt="Roave" class="spons-logo" /></a>
             <h2>Roave</h2>
             <p>Roave is a full-service web development firm, offering services such as consulting, training, software development, and more. Roave employs some of the most recognized and accomplished experts in the industry to ensure that organizations have access to the talent they need, when they need it.</p>
             <p>Visit: <a href="https://roave.com/">roave.com</a></p>
         </li>
 
         <li class="sponsor">
-            <a href="http://www.jetbrains.com/phpstorm/"><img src="/images/phpstorm.png" alt="JetBrains PhpStorm" class="sponsor-logo" /></a>
+            <a href="http://www.jetbrains.com/phpstorm/"><img src="/images/phpstorm.png" alt="JetBrains PhpStorm" class="spons-logo" /></a>
             <h2>JetBrains PhpStorm</h2>
             <p>PhpStorm keeps up with latest PHP &amp; web languages trends, integrates a variety of modern tools, and brings even more extensibility with support for major PHP frameworks.</p>
             <p>Visit: <a href="http://www.jetbrains.com/phpstorm/">www.jetbrains.com/phpstorm</a></p>
         </li>
 
         <li class="sponsor">
-            <a href="http://www.oreilly.com/"><img src="/images/oreilly-ug.gif" alt="O'Reilly" class="sponsor-logo" /></a>
+            <a href="http://www.oreilly.com/"><img src="/images/oreilly-ug.gif" alt="O'Reilly" class="spons-logo" /></a>
             <h2>O'Reilly User Group Program</h2>
             <p>PHP Hampshire is proud to be part of the O'Reilly User Group Program, which means our members can benefit from discounts (40% off printed books, 50% off e-books) and other goodies sometimes.</p>
             <p>Visit: <a href="http://www.oreilly.com/">www.oreilly.com</a></p>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -473,7 +473,7 @@ header .nav-button:active{
 
 .content .sponsor:last-child{ border: none; }
 
-.sponsor-logo {
+.spons-logo {
 	width: 200px;
 }
 


### PR DESCRIPTION
I was wondering why I couldn't see any images

![adblock-sponsor-logo](https://cloud.githubusercontent.com/assets/98873/13187540/89cbff58-d743-11e5-9a22-04fad973b2fb.png)
