### PR TITLE
Improve footer styling, fixes #76

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -204,9 +204,10 @@ html {
 }
 
 body {
-	margin-bottom: 125px;
-	padding-bottom: 25px;
-
+	display: flex;
+	flex-direction: column;
+	min-height: 100vh;
+	
 	font-family: "Open Sans", sans-serif;
 
 	background: #eee;
@@ -446,6 +447,7 @@ header .nav-button:active{
 }
 
 .content{
+	flex: 1;
 	padding: 1em .5em;
 	overflow: hidden; /* acts as a clearfix */
 }
@@ -586,8 +588,6 @@ p.talk-abstract {
 }
 
 footer {
-	position: absolute;
-	bottom: 0;
 	width: 100%;
 	padding: 1em;
 


### PR DESCRIPTION
Fixes #76 

Fixed it eventually...

Footer stays at the bottom because the content sections grow to fill the space.