### PR TITLE
Meetup attendance

### DIFF
--- a/config/autoload/routes.global.php
+++ b/config/autoload/routes.global.php
@@ -25,6 +25,7 @@ return [
             App\Action\Account\Meetup\AddMeetupAction::class => App\Action\Account\Meetup\AddMeetupActionFactory::class,
             App\Action\Account\Meetup\EditMeetupAction::class => App\Action\Account\Meetup\EditMeetupActionFactory::class,
             App\Action\Account\Meetup\ViewMeetupAction::class => App\Action\Account\Meetup\ViewMeetupActionFactory::class,
+            App\Action\Account\Meetup\ToggleAttendanceAction::class => App\Action\Account\Meetup\ToggleAttendanceActionFactory::class,
             App\Action\Account\Meetup\ListMeetupsAction::class => App\Action\Account\Meetup\ListMeetupsActionFactory::class,
             App\Action\Account\Location\ListLocationsAction::class => App\Action\Account\Location\ListLocationsActionFactory::class,
             App\Action\Account\Location\AddLocationAction::class => App\Action\Account\Location\AddLocationActionFactory::class,
@@ -168,6 +169,16 @@ return [
                 App\Action\Account\Meetup\EditMeetupAction::class,
             ],
             'allowed_methods' => ['GET', 'POST'],
+        ],
+        [
+            'name' => 'account-meetup-toggle-attendance',
+            'path' => '/account/meetup/{uuid}/toggle-attendance',
+            'middleware' => [
+                App\Middleware\Authentication::class,
+                App\Service\Authorization\Middleware\HasAttendeeRoleMiddleware::class,
+                App\Action\Account\Meetup\ToggleAttendanceAction::class,
+            ],
+            'allowed_methods' => ['POST'],
         ],
         [
             'name' => 'account-locations-list',

--- a/data/migrations/Version20170108142822.php
+++ b/data/migrations/Version20170108142822.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Add meetup attendance records
+ */
+class Version20170108142822 extends AbstractMigration
+{
+    /**
+     * {@inheritdoc}
+     * @throws \Doctrine\DBAL\Migrations\AbortMigrationException
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf(
+            $this->connection->getDatabasePlatform()->getName() !== 'postgresql',
+            'Migration can only be executed safely on \'postgresql\'.'
+        );
+
+        $this->addSql('CREATE TABLE meetup_attendees (meetup_id UUID NOT NULL, user_id UUID NOT NULL, PRIMARY KEY(meetup_id, user_id))');
+        $this->addSql('CREATE INDEX IDX_FB2E8EEC591E2316 ON meetup_attendees (meetup_id)');
+        $this->addSql('CREATE INDEX IDX_FB2E8EECA76ED395 ON meetup_attendees (user_id)');
+        $this->addSql('ALTER TABLE meetup_attendees ADD CONSTRAINT FK_FB2E8EEC591E2316 FOREIGN KEY (meetup_id) REFERENCES meetup (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE meetup_attendees ADD CONSTRAINT FK_FB2E8EECA76ED395 FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    /**
+     * {@inheritdoc}
+     * @throws \Doctrine\DBAL\Migrations\AbortMigrationException
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf(
+            $this->connection->getDatabasePlatform()->getName() !== 'postgresql',
+            'Migration can only be executed safely on \'postgresql\'.'
+        );
+
+        $this->addSql('DROP TABLE meetup_attendees');
+    }
+}

--- a/data/migrations/Version20170108160758.php
+++ b/data/migrations/Version20170108160758.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Add Display Name to users
+ */
+class Version20170108160758 extends AbstractMigration
+{
+    /**
+     * {@inheritdoc}
+     * @throws \Doctrine\DBAL\Migrations\AbortMigrationException
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf(
+            $this->connection->getDatabasePlatform()->getName() !== 'postgresql',
+            'Migration can only be executed safely on \'postgresql\'.'
+        );
+
+        $this->addSql('ALTER TABLE "user" ADD display_name VARCHAR(1024)');
+        $this->addSql('UPDATE "user" SET display_name = email');
+
+        // No way of knowing names, so just populate with email; manually fix
+        $this->addSql('ALTER TABLE "user" ALTER COLUMN display_name SET NOT NULL');
+    }
+
+    /**
+     * {@inheritdoc}
+     * @throws \Doctrine\DBAL\Migrations\AbortMigrationException
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf(
+            $this->connection->getDatabasePlatform()->getName() !== 'postgresql',
+            'Migration can only be executed safely on \'postgresql\'.'
+        );
+
+        $this->addSql('ALTER TABLE "user" DROP display_name');
+    }
+}

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -207,7 +207,7 @@ body {
 	display: flex;
 	flex-direction: column;
 	min-height: 100vh;
-	
+
 	font-family: "Open Sans", sans-serif;
 
 	background: #eee;
@@ -692,4 +692,30 @@ ul#team li img {
 
 .error {
 	color: #ff0000;
+}
+
+.attending-button {
+    border: 1px solid grey;
+    background-color: silver;
+    display: inline-block;
+    border-radius: 5px;
+    color: white;
+    text-decoration: none;
+    padding: 0 5px;
+    margin: 0 5px;
+    font-weight: normal;
+}
+.attending-button:hover {
+    background-color: grey;
+}
+.attending-button.is-attending {
+    background-color: #005500;
+    border-color: #003300;
+    color: #ffffff;
+}
+.attending-button.is-attending:hover {
+    background-color: #004400;
+}
+.attending-button.is-attending:before {
+    content: '\2713';
 }

--- a/public/js/scripts.js
+++ b/public/js/scripts.js
@@ -147,4 +147,22 @@ $(document).ready(function(){
         }
     });
 
+    $('.attending-button').click(function (e) {
+        var attendingButton = $(this);
+        e.preventDefault();
+        $.post(attendingButton.attr('href'))
+            .done(function (result) {
+                if (result.attending) {
+                    attendingButton.addClass('is-attending');
+                    attendingButton.text(result.isPast ? 'I went to this' : 'I will be there');
+                    return;
+                }
+                attendingButton.removeClass('is-attending');
+                attendingButton.text(result.isPast ? 'I wasn\'t there' : 'I won\'t be there');
+            })
+            .fail(function () {
+                alert('Could not toggle your attendance status...');
+            })
+    });
+
 });

--- a/src/App/Action/Account/Meetup/ToggleAttendanceAction.php
+++ b/src/App/Action/Account/Meetup/ToggleAttendanceAction.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types = 1);
+
+namespace App\Action\Account\Meetup;
+
+use App\Service\Authentication\AuthenticationServiceInterface;
+use App\Service\Meetup\FindMeetupByUuidInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Ramsey\Uuid\Uuid;
+use Zend\Diactoros\Response\JsonResponse;
+use Zend\Stratigility\MiddlewareInterface;
+
+final class ToggleAttendanceAction implements MiddlewareInterface
+{
+    /**
+     * @var EntityManagerInterface
+     */
+    private $entityManager;
+
+    /**
+     * @var FindMeetupByUuidInterface
+     */
+    private $findMeetupByUuid;
+
+    /**
+     * @var AuthenticationServiceInterface
+     */
+    private $authenticationService;
+
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        FindMeetupByUuidInterface $findMeetupByUuid,
+        AuthenticationServiceInterface $authenticationService
+    ) {
+        $this->entityManager = $entityManager;
+        $this->findMeetupByUuid = $findMeetupByUuid;
+        $this->authenticationService = $authenticationService;
+    }
+
+    public function __invoke(Request $request, Response $response, callable $next = null) : Response
+    {
+        $meetup = $this->findMeetupByUuid->__invoke(Uuid::fromString($request->getAttribute('uuid')));
+        $user = $this->authenticationService->getIdentity();
+
+        $now = new \DateTimeImmutable();
+
+        return new JsonResponse(
+            $this->entityManager->transactional(function () use ($user, $meetup, $now) {
+                if ($user->isAttending($meetup)) {
+                    $meetup->cancelAttendance($user);
+                    return [
+                        'attending' => false,
+                        'isPast' => $meetup->isBefore($now),
+                    ];
+                }
+
+                $meetup->attend($user);
+                return [
+                    'attending' => true,
+                    'isPast' => $meetup->isBefore($now),
+                ];
+            }),
+            200
+        );
+    }
+}

--- a/src/App/Action/Account/Meetup/ToggleAttendanceActionFactory.php
+++ b/src/App/Action/Account/Meetup/ToggleAttendanceActionFactory.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Action\Account\Meetup;
+
+use App\Service\Authentication\AuthenticationServiceInterface;
+use App\Service\Meetup\FindMeetupByUuidInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Interop\Container\ContainerInterface;
+
+/**
+ * @codeCoverageIgnore
+ */
+final class ToggleAttendanceActionFactory
+{
+    public function __invoke(ContainerInterface $container) : ToggleAttendanceAction
+    {
+        return new ToggleAttendanceAction(
+            $container->get(EntityManagerInterface::class),
+            $container->get(FindMeetupByUuidInterface::class),
+            $container->get(AuthenticationServiceInterface::class)
+        );
+    }
+}

--- a/src/App/Action/Account/RegisterAction.php
+++ b/src/App/Action/Account/RegisterAction.php
@@ -67,7 +67,7 @@ final class RegisterAction implements MiddlewareInterface
 
                 $this->entityManager->transactional(function () use ($data) {
                     $this->entityManager->persist(
-                        User::new($data['email'], $this->passwordAlgorithm, $data['password'])
+                        User::new($data['email'], $data['name'], $this->passwordAlgorithm, $data['password'])
                     );
                 });
                 return new RedirectResponse($this->urlHelper->generate('account-login'));

--- a/src/App/Entity/Meetup.php
+++ b/src/App/Entity/Meetup.php
@@ -62,10 +62,18 @@ use Ramsey\Uuid\Uuid;
      */
     private $talks;
 
+    /**
+     * @ORM\ManyToMany(targetEntity=User::class, inversedBy="meetupsAttended")
+     * @ORM\JoinTable(name="meetup_attendees")
+     * @var Meetup[]
+     */
+    private $attendees;
+
     private function __construct()
     {
         $this->id = Uuid::uuid4();
         $this->talks = new ArrayCollection();
+        $this->attendees = new ArrayCollection();
     }
 
     /**

--- a/src/App/Entity/Meetup.php
+++ b/src/App/Entity/Meetup.php
@@ -174,4 +174,16 @@ use Ramsey\Uuid\Uuid;
     {
         return ($this->toDate < $date);
     }
+
+    public function attend(User $user) : void
+    {
+        $this->attendees->add($user);
+        $user->meetupsAttended()->add($this);
+    }
+
+    public function cancelAttendance(User $user) : void
+    {
+        $this->attendees->removeElement($user);
+        $user->meetupsAttended()->removeElement($this);
+    }
 }

--- a/src/App/Entity/User.php
+++ b/src/App/Entity/User.php
@@ -44,6 +44,12 @@ use Ramsey\Uuid\Uuid;
     private $role;
 
     /**
+     * @ORM\Column(name="display_name", type="string", length=1024, nullable=false)
+     * @var string
+     */
+    private $displayName;
+
+    /**
      * @ORM\ManyToMany(targetEntity=Meetup::class, mappedBy="attendees")
      * @var Meetup[]
      */
@@ -55,10 +61,11 @@ use Ramsey\Uuid\Uuid;
         $this->meetupsAttended = new ArrayCollection();
     }
 
-    public static function new(string $email, PasswordHashInterface $algorithm, string $password) : self
+    public static function new(string $email, string $displayName, PasswordHashInterface $algorithm, string $password) : self
     {
         $instance = new self();
         $instance->email = $email;
+        $instance->displayName = $displayName;
         $instance->password = $algorithm->hash($password);
         $instance->role = AttendeeRole::NAME;
         return $instance;
@@ -67,6 +74,11 @@ use Ramsey\Uuid\Uuid;
     public function getEmail() : string
     {
         return $this->email;
+    }
+
+    public function displayName() : string
+    {
+        return $this->displayName;
     }
 
     public function verifyPassword(PasswordHashInterface $algorithm, string $password) : bool

--- a/src/App/Entity/User.php
+++ b/src/App/Entity/User.php
@@ -61,8 +61,12 @@ use Ramsey\Uuid\Uuid;
         $this->meetupsAttended = new ArrayCollection();
     }
 
-    public static function new(string $email, string $displayName, PasswordHashInterface $algorithm, string $password) : self
-    {
+    public static function new(
+        string $email,
+        string $displayName,
+        PasswordHashInterface $algorithm,
+        string $password
+    ) : self {
         $instance = new self();
         $instance->email = $email;
         $instance->displayName = $displayName;

--- a/src/App/Entity/User.php
+++ b/src/App/Entity/User.php
@@ -8,6 +8,7 @@ use App\Service\Authorization\Role\RoleFactory;
 use App\Service\Authorization\Role\RoleInterface;
 use App\Service\User\PasswordHashInterface;
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Ramsey\Uuid\Uuid;
 
@@ -80,5 +81,15 @@ use Ramsey\Uuid\Uuid;
     public function getRole() : RoleInterface
     {
         return RoleFactory::getRole($this->role);
+    }
+
+    public function isAttending(Meetup $meetup) : bool
+    {
+        return $this->meetupsAttended->contains($meetup);
+    }
+
+    public function meetupsAttended() : Collection
+    {
+        return $this->meetupsAttended;
     }
 }

--- a/src/App/Entity/User.php
+++ b/src/App/Entity/User.php
@@ -7,6 +7,7 @@ use App\Service\Authorization\Role\AttendeeRole;
 use App\Service\Authorization\Role\RoleFactory;
 use App\Service\Authorization\Role\RoleInterface;
 use App\Service\User\PasswordHashInterface;
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Ramsey\Uuid\Uuid;
 
@@ -41,9 +42,16 @@ use Ramsey\Uuid\Uuid;
      */
     private $role;
 
+    /**
+     * @ORM\ManyToMany(targetEntity=Meetup::class, mappedBy="attendees")
+     * @var Meetup[]
+     */
+    private $meetupsAttended;
+
     private function __construct()
     {
         $this->id = Uuid::uuid4();
+        $this->meetupsAttended = new ArrayCollection();
     }
 
     public static function new(string $email, PasswordHashInterface $algorithm, string $password) : self

--- a/src/App/Form/Account/RegisterForm.php
+++ b/src/App/Form/Account/RegisterForm.php
@@ -3,6 +3,8 @@ declare(strict_types = 1);
 
 namespace App\Form\Account;
 
+use Zend\Filter\StringTrim;
+use Zend\Filter\StripTags;
 use Zend\Form\Element\Csrf;
 use Zend\Form\Element\Hidden;
 use Zend\Form\Element\Password;
@@ -37,6 +39,7 @@ class RegisterForm extends Form implements InputFilterProviderInterface
         $this->recaptchaValidator = $recaptchaValidator;
         $this->userDoesNotExistValidator = $userDoesNotExistValidator;
 
+        $this->add((new Text('name'))->setLabel('Your Name'));
         $this->add((new Text('email'))->setLabel('Email Address'));
         $this->add((new Password('password'))->setLabel('Password'));
         $this->add((new Password('confirmPassword'))->setLabel('Confirm Password'));
@@ -55,6 +58,13 @@ class RegisterForm extends Form implements InputFilterProviderInterface
     public function getInputFilterSpecification() : array
     {
         return [
+            'name' => [
+                'required' => true,
+                'filters' => [
+                    ['name' => StringTrim::class],
+                    ['name' => StripTags::class],
+                ],
+            ],
             'email' => [
                 'required' => true,
                 'validators' => [

--- a/src/App/View/Helper/User.php
+++ b/src/App/View/Helper/User.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace App\View\Helper;
 
+use App\Entity\User as UserEntity;
 use App\Service\Authentication\AuthenticationServiceInterface;
 use App\Service\Authorization\AuthorizationServiceInterface;
 use App\Service\Authorization\Role\AdministratorRole;
@@ -37,5 +38,15 @@ final class User extends AbstractHelper
     public function isAdministrator() : bool
     {
         return $this->authorizationService->hasRole(new AdministratorRole());
+    }
+
+    public function isAttendee() : bool
+    {
+        return $this->authorizationService->hasRole(new AttendeeRole());
+    }
+
+    public function get() : UserEntity
+    {
+        return $this->authenticationService->getIdentity();
     }
 }

--- a/templates/app/account/register.phtml
+++ b/templates/app/account/register.phtml
@@ -17,6 +17,8 @@ $this->headTitle($title);
 
     <?= $this->form()->openTag($form); ?>
 
+    <?= $this->formRow($form->get('name')); ?>
+
     <?= $this->formRow($form->get('email')->setAttributes([
         'placeholder' => 'foo@bar.com',
     ])); ?>

--- a/templates/layout/attending-button.phtml
+++ b/templates/layout/attending-button.phtml
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types = 1);
+
+/** @var \App\Entity\Meetup $meetup */
+
+if ($this->user()->isAttendee()) {
+    /** @var \App\Entity\User $user */
+    $user = $this->user()->get();
+
+    $isPast = $meetup->isBefore(new \DateTimeImmutable());
+    $isAttending = $user->isAttending($meetup);
+
+    if ($isAttending) {
+        $label = $isPast ? 'I went to this' : 'I will be there';
+    } else {
+        $label = $isPast ? 'I wasn\'t there' : 'I won\'t be there';
+    }
+
+    ?>
+    <a
+        href="<?= $this->escapeHtmlAttr($this->url('account-meetup-toggle-attendance', ['uuid' => $meetup->getId()])); ?>"
+        class="attending-button <?= $isAttending ? 'is-attending' : ''; ?>"
+    >
+        <?= $label; ?>
+    </a>
+    <?php
+}

--- a/templates/layout/single-meetup-abbreviated.phtml
+++ b/templates/layout/single-meetup-abbreviated.phtml
@@ -7,7 +7,7 @@ declare(strict_types = 1);
 $abbreviatedTalks = $meetup->getAbbreviatedTalks();
 ?>
 
-<h2><?= $meetup->getFromDate()->format('jS F Y'); ?></h2>
+<h2><?= $meetup->getFromDate()->format('jS F Y'); ?> <?= $this->partial('layout::attending-button', ['meetup' => $meetup]); ?></h2>
 
 <?php if (count($abbreviatedTalks) > 0): ?>
 <ul class="meetup-details">

--- a/templates/layout/single-meetup-full.phtml
+++ b/templates/layout/single-meetup-full.phtml
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 /** @var \App\Entity\Meetup $meetup */
 ?>
 
-<h2><?= $meetup->getFromDate()->format('jS F Y'); ?></h2>
+<h2><?= $meetup->getFromDate()->format('jS F Y'); ?> <?= $this->partial('layout::attending-button', ['meetup' => $meetup]); ?></h2>
 
 <ul class="meetup-details">
     <li>

--- a/test/AppTest/Action/Account/Meetup/ToggleAttendanceActionTest.php
+++ b/test/AppTest/Action/Account/Meetup/ToggleAttendanceActionTest.php
@@ -1,0 +1,128 @@
+<?php
+declare(strict_types = 1);
+
+namespace AppTest\Action\Account\Meetup;
+
+use App\Action\Account\Meetup\ToggleAttendanceAction;
+use App\Entity\Location;
+use App\Entity\Meetup;
+use App\Entity\User;
+use App\Service\Authentication\AuthenticationServiceInterface;
+use App\Service\Location\FindLocationByUuidInterface;
+use App\Service\Meetup\FindMeetupByUuidInterface;
+use App\Service\User\PhpPasswordHash;
+use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
+use Zend\Diactoros\Response;
+use Zend\Diactoros\ServerRequest;
+use Zend\Expressive\Helper\UrlHelper;
+use Zend\Expressive\Template\TemplateRendererInterface;
+use Zend\Form\FormInterface;
+
+/**
+ * @covers \App\Action\Account\Meetup\ToggleAttendanceAction
+ */
+final class ToggleAttendanceActionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Meetup
+     */
+    private $meetup;
+
+    /**
+     * @var User
+     */
+    private $user;
+
+    /**
+     * @var EntityManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $entityManager;
+
+    /**
+     * @var FindMeetupByUuidInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $findMeetup;
+
+    /**
+     * @var AuthenticationServiceInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $authenticationService;
+
+    /**
+     * @var ToggleAttendanceAction
+     */
+    private $action;
+
+    public function setUp()
+    {
+        $this->meetup = Meetup::fromStandardMeetup(
+            new \DateTimeImmutable('2016-06-01 19:00:00'),
+            new \DateTimeImmutable('2016-06-01 23:00:00'),
+            Location::fromNameAddressAndUrl('Location 1', 'Address 1', 'http://test-uri-1')
+        );
+
+        $this->user = User::new('foo@bar.com', new PhpPasswordHash(), 'correct horse battery staple');
+
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+
+        $this->findMeetup = $this->createMock(FindMeetupByUuidInterface::class);
+        $this->findMeetup->expects(self::once())
+            ->method('__invoke')
+            ->with($this->meetup->getId())
+            ->willReturn($this->meetup);
+
+        $this->authenticationService = $this->createMock(AuthenticationServiceInterface::class);
+        $this->authenticationService->expects(self::once())->method('getIdentity')->willReturn($this->user);
+
+        $this->action = new ToggleAttendanceAction(
+            $this->entityManager,
+            $this->findMeetup,
+            $this->authenticationService
+        );
+    }
+
+    public function testAttendingUserCancelsAttendance()
+    {
+        $this->meetup->attend($this->user);
+
+        $this->entityManager->expects(self::once())->method('transactional')->willReturnCallback('call_user_func');
+
+        $response = $this->action->__invoke(
+            (new ServerRequest())
+                ->withMethod('POST')
+                ->withAttribute('uuid', $this->meetup->getId()),
+            new Response()
+        );
+
+        self::assertInstanceOf(Response\JsonResponse::class, $response);
+        self::assertSame(
+            [
+                'attending' => false,
+                'isPast' => true,
+            ],
+            json_decode($response->getBody()->getContents(), true)
+        );
+    }
+
+    public function testUnattendingUserMarksAttendance()
+    {
+        $this->entityManager->expects(self::once())->method('transactional')->willReturnCallback('call_user_func');
+
+        $response = $this->action->__invoke(
+            (new ServerRequest())
+                ->withMethod('POST')
+                ->withAttribute('uuid', $this->meetup->getId()),
+            new Response()
+        );
+
+        self::assertInstanceOf(Response\JsonResponse::class, $response);
+        self::assertSame(
+            [
+                'attending' => true,
+                'isPast' => true,
+            ],
+            json_decode($response->getBody()->getContents(), true)
+        );
+    }
+}

--- a/test/AppTest/Action/Account/Meetup/ToggleAttendanceActionTest.php
+++ b/test/AppTest/Action/Account/Meetup/ToggleAttendanceActionTest.php
@@ -62,7 +62,7 @@ final class ToggleAttendanceActionTest extends \PHPUnit_Framework_TestCase
             Location::fromNameAddressAndUrl('Location 1', 'Address 1', 'http://test-uri-1')
         );
 
-        $this->user = User::new('foo@bar.com', new PhpPasswordHash(), 'correct horse battery staple');
+        $this->user = User::new('foo@bar.com', 'My Name', new PhpPasswordHash(), 'correct horse battery staple');
 
         $this->entityManager = $this->createMock(EntityManagerInterface::class);
 

--- a/test/AppTest/Action/Account/RegisterActionTest.php
+++ b/test/AppTest/Action/Account/RegisterActionTest.php
@@ -12,7 +12,6 @@ use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequest;
 use Zend\Expressive\Helper\UrlHelper;
 use Zend\Expressive\Template\TemplateRendererInterface;
-use Zend\Form\Element\Text;
 use Zend\Form\FormInterface;
 
 /**
@@ -99,6 +98,7 @@ final class RegisterActionTest extends \PHPUnit_Framework_TestCase
         $this->urlHelper->expects(self::never())->method('generate');
 
         $this->form->expects(self::once())->method('setData')->with([
+            'name' => '',
             'email' => '',
             'password' => '',
             'confirmPassword' => '',
@@ -110,6 +110,7 @@ final class RegisterActionTest extends \PHPUnit_Framework_TestCase
             (new ServerRequest(['/']))
                 ->withMethod('post')
                 ->withParsedBody([
+                    'name' => '',
                     'email' => '',
                     'password' => '',
                     'confirmPassword' => '',
@@ -124,10 +125,12 @@ final class RegisterActionTest extends \PHPUnit_Framework_TestCase
 
     public function testValidPostRequestCreatesUserAndRedirects()
     {
+        $name = uniqid('name', true);
         $email = uniqid('email', true);
         $password = uniqid('password', true);
         $hash = uniqid('hash', true);
         $data = [
+            'name' => $name,
             'email' => $email,
             'password' => $password,
             'confirmPassword' => $password,
@@ -136,7 +139,8 @@ final class RegisterActionTest extends \PHPUnit_Framework_TestCase
         $this->entityManager->expects(self::once())->method('transactional')->willReturnCallback('call_user_func');
         $this->entityManager->expects(self::once())
             ->method('persist')
-            ->with(self::callback(function (User $user) use ($email, $password) {
+            ->with(self::callback(function (User $user) use ($name, $email, $password) {
+                self::assertSame($name, $user->displayName());
                 self::assertSame($email, $user->getEmail());
                 self::assertInstanceOf(AttendeeRole::class, $user->getRole());
                 self::assertTrue($user->verifyPassword($this->hasher, $password));

--- a/test/AppTest/Entity/MeetupTest.php
+++ b/test/AppTest/Entity/MeetupTest.php
@@ -8,6 +8,8 @@ use App\Entity\Location;
 use App\Entity\Meetup;
 use App\Entity\Speaker;
 use App\Entity\Talk;
+use App\Entity\User;
+use App\Service\User\PhpPasswordHash;
 use Assert\InvalidArgumentException;
 use Ramsey\Uuid\Uuid;
 
@@ -133,5 +135,23 @@ class MeetupTest extends \PHPUnit_Framework_TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('To date should be after From date');
         $meetup->updateFromData($newFrom, $newTo, $location);
+    }
+
+    public function testAttendance()
+    {
+        $from = new \DateTimeImmutable('2016-06-01 19:00:00');
+        $to = new \DateTimeImmutable('2016-06-01 23:00:00');
+        $location = Location::fromNameAddressAndUrl('Location 1', 'Address 1', 'http://test-uri-1');
+
+        $meetup = Meetup::fromStandardMeetup($from, $to, $location);
+
+        $user = User::new('foo@bar.com', new PhpPasswordHash(), 'password');
+        self::assertFalse($user->isAttending($meetup));
+
+        $meetup->attend($user);
+        self::assertTrue($user->isAttending($meetup));
+
+        $meetup->cancelAttendance($user);
+        self::assertFalse($user->isAttending($meetup));
     }
 }

--- a/test/AppTest/Entity/MeetupTest.php
+++ b/test/AppTest/Entity/MeetupTest.php
@@ -145,7 +145,7 @@ class MeetupTest extends \PHPUnit_Framework_TestCase
 
         $meetup = Meetup::fromStandardMeetup($from, $to, $location);
 
-        $user = User::new('foo@bar.com', new PhpPasswordHash(), 'password');
+        $user = User::new('foo@bar.com', 'My Name', new PhpPasswordHash(), 'password');
         self::assertFalse($user->isAttending($meetup));
 
         $meetup->attend($user);

--- a/test/AppTest/Entity/UserTest.php
+++ b/test/AppTest/Entity/UserTest.php
@@ -3,6 +3,8 @@ declare(strict_types = 1);
 
 namespace AppTest\Entity;
 
+use App\Entity\Location;
+use App\Entity\Meetup;
 use App\Entity\User;
 use App\Service\Authorization\Role\AdministratorRole;
 use App\Service\Authorization\Role\AttendeeRole;
@@ -82,5 +84,23 @@ class UserTest extends \PHPUnit_Framework_TestCase
             User::new('foo@bar.com', new PhpPasswordHash(), 'password')
                 ->getRole()
         );
+    }
+
+    public function testMeetupAttendance()
+    {
+        $from = new \DateTimeImmutable('2016-06-01 19:00:00');
+        $to = new \DateTimeImmutable('2016-06-01 23:00:00');
+        $location = Location::fromNameAddressAndUrl('Location 1', 'Address 1', 'http://test-uri-1');
+
+        $meetup = Meetup::fromStandardMeetup($from, $to, $location);
+
+        $user = User::new('foo@bar.com', new PhpPasswordHash(), 'password');
+        self::assertFalse($user->isAttending($meetup));
+
+        $meetup->attend($user);
+        self::assertTrue($user->isAttending($meetup));
+
+        $meetup->cancelAttendance($user);
+        self::assertFalse($user->isAttending($meetup));
     }
 }

--- a/test/AppTest/Entity/UserTest.php
+++ b/test/AppTest/Entity/UserTest.php
@@ -19,9 +19,17 @@ class UserTest extends \PHPUnit_Framework_TestCase
     public function testGetEmail()
     {
         $email = uniqid('email', true);
-        $user = User::new($email, new PhpPasswordHash(), '');
+        $user = User::new($email, 'My Name', new PhpPasswordHash(), '');
 
         self::assertSame($email, $user->getEmail());
+    }
+
+    public function testGetDisplayName()
+    {
+        $displayName = uniqid('displayName', true);
+        $user = User::new('foo@bar.com', $displayName, new PhpPasswordHash(), '');
+
+        self::assertSame($displayName, $user->displayName());
     }
 
     public function testPasswordVerification()
@@ -30,7 +38,7 @@ class UserTest extends \PHPUnit_Framework_TestCase
 
         $hasher = new PhpPasswordHash();
 
-        $user = User::new('foo@bar.com', $hasher, $plaintext);
+        $user = User::new('foo@bar.com', 'My Name', $hasher, $plaintext);
 
         self::assertFalse($user->verifyPassword($hasher, uniqid('incorrect password', true)));
         self::assertTrue($user->verifyPassword($hasher, $plaintext));
@@ -43,7 +51,7 @@ class UserTest extends \PHPUnit_Framework_TestCase
         $hasher->expects(self::never())->method('verify');
 
         $originalPassword = uniqid('plaintext', true);
-        $user = User::new('foo@bar.com', $hasher, $originalPassword);
+        $user = User::new('foo@bar.com', 'My Name', $hasher, $originalPassword);
 
         $passwordProperty = new \ReflectionProperty($user, 'password');
         $passwordProperty->setAccessible(true);
@@ -68,7 +76,7 @@ class UserTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetRole(string $roleName, string $expectedClass)
     {
-        $user = User::new('foo@bar.com', new PhpPasswordHash(), 'password');
+        $user = User::new('foo@bar.com', 'My Name', new PhpPasswordHash(), 'password');
 
         $roleProperty = new \ReflectionProperty($user, 'role');
         $roleProperty->setAccessible(true);
@@ -81,7 +89,7 @@ class UserTest extends \PHPUnit_Framework_TestCase
     {
         self::assertInstanceOf(
             AttendeeRole::class,
-            User::new('foo@bar.com', new PhpPasswordHash(), 'password')
+            User::new('foo@bar.com', 'My Name', new PhpPasswordHash(), 'password')
                 ->getRole()
         );
     }
@@ -94,7 +102,7 @@ class UserTest extends \PHPUnit_Framework_TestCase
 
         $meetup = Meetup::fromStandardMeetup($from, $to, $location);
 
-        $user = User::new('foo@bar.com', new PhpPasswordHash(), 'password');
+        $user = User::new('foo@bar.com', 'My Name', new PhpPasswordHash(), 'password');
         self::assertFalse($user->isAttending($meetup));
 
         $meetup->attend($user);

--- a/test/AppTest/Form/Account/RegisterFormTest.php
+++ b/test/AppTest/Form/Account/RegisterFormTest.php
@@ -27,6 +27,7 @@ final class RegisterFormTest extends \PHPUnit_Framework_TestCase
         $userExistsValidator = $this->createMock(ValidatorInterface::class);
         $form = new RegisterForm($recaptchaValidator, $recaptchaKey, $userExistsValidator);
 
+        self::assertInstanceOf(Text::class, $form->get('name'));
         self::assertInstanceOf(Text::class, $form->get('email'));
         self::assertInstanceOf(Password::class, $form->get('password'));
         self::assertInstanceOf(Password::class, $form->get('confirmPassword'));
@@ -48,6 +49,7 @@ final class RegisterFormTest extends \PHPUnit_Framework_TestCase
         $form->getInputFilter()->remove('submit');
 
         $form->setData([
+            'name' => '',
             'email' => '',
             'password' => '',
             'confirmPassword' => '',
@@ -56,6 +58,9 @@ final class RegisterFormTest extends \PHPUnit_Framework_TestCase
         self::assertFalse($form->isValid());
         self::assertSame(
             [
+                'name' => [
+                    'isEmpty' => 'Value is required and can\'t be empty',
+                ],
                 'email' => [
                     'isEmpty' => 'Value is required and can\'t be empty',
                 ],
@@ -93,6 +98,7 @@ final class RegisterFormTest extends \PHPUnit_Framework_TestCase
         $form->getInputFilter()->remove('submit');
 
         $form->setData([
+            'name' => '',
             'email' => uniqid('not a valid email', true),
             'password' => 'pwd',
             'confirmPassword' => uniqid('confirmPassword', true),
@@ -102,6 +108,9 @@ final class RegisterFormTest extends \PHPUnit_Framework_TestCase
         self::assertFalse($form->isValid());
         self::assertSame(
             [
+                'name' => [
+                    'isEmpty' => 'Value is required and can\'t be empty',
+                ],
                 'email' => [
                     'emailAddressInvalidFormat'
                         => 'The input is not a valid email address. Use the basic format local-part@hostname',
@@ -136,6 +145,7 @@ final class RegisterFormTest extends \PHPUnit_Framework_TestCase
 
         $password = uniqid('correct horse battery staple', true);
         $form->setData([
+            'name' => uniqid('My Name', true),
             'email' => 'valid@email.com',
             'password' => $password,
             'confirmPassword' => $password,

--- a/test/AppTest/Service/Authentication/ZendAuthenticationServiceTest.php
+++ b/test/AppTest/Service/Authentication/ZendAuthenticationServiceTest.php
@@ -44,7 +44,7 @@ class ZendAuthenticationServiceTest extends \PHPUnit_Framework_TestCase
         $hasher->expects(self::once())->method('hash')->with($correctPassword)->willReturn($hash);
         $hasher->expects(self::once())->method('verify')->with($incorrectPassword, $hash)->willReturn(false);
 
-        $user = User::new($email, $hasher, $correctPassword);
+        $user = User::new($email, 'My Name', $hasher, $correctPassword);
 
         /** @var FindUserByEmailInterface|\PHPUnit_Framework_MockObject_MockObject $users */
         $users = $this->createMock(FindUserByEmailInterface::class);
@@ -70,7 +70,7 @@ class ZendAuthenticationServiceTest extends \PHPUnit_Framework_TestCase
         $hasher->expects(self::once())->method('hash')->with($correctPassword)->willReturn($hash);
         $hasher->expects(self::once())->method('verify')->with($correctPassword, $hash)->willReturn(true);
 
-        $user = User::new($email, $hasher, $correctPassword);
+        $user = User::new($email, 'My Name', $hasher, $correctPassword);
 
         /** @var FindUserByEmailInterface|\PHPUnit_Framework_MockObject_MockObject $users */
         $users = $this->createMock(FindUserByEmailInterface::class);

--- a/test/AppTest/Validator/UserDoesNotExistValidatorTest.php
+++ b/test/AppTest/Validator/UserDoesNotExistValidatorTest.php
@@ -37,7 +37,7 @@ class UserDoesNotExistValidatorTest extends \PHPUnit_Framework_TestCase
         $findUserByEmail->expects(self::once())
             ->method('__invoke')
             ->with($email)
-            ->willReturn(User::new($email, new PhpPasswordHash(), 'correct horse battery staple'));
+            ->willReturn(User::new($email, 'My Name', new PhpPasswordHash(), 'correct horse battery staple'));
 
         $validator = new UserDoesNotExistValidator($findUserByEmail);
         self::assertFalse($validator->isValid($email));

--- a/test/AppTest/View/Helper/UserTest.php
+++ b/test/AppTest/View/Helper/UserTest.php
@@ -3,9 +3,12 @@ declare(strict_types = 1);
 
 namespace AppTest\View\Helper;
 
+use App\Entity\User as UserEntity;
 use App\Service\Authentication\AuthenticationServiceInterface;
 use App\Service\Authorization\AuthorizationServiceInterface;
 use App\Service\Authorization\Role\AdministratorRole;
+use App\Service\Authorization\Role\AttendeeRole;
+use App\Service\User\PhpPasswordHash;
 use App\View\Helper\User;
 
 /**
@@ -65,5 +68,49 @@ class UserTest extends \PHPUnit_Framework_TestCase
             ->willReturn(false);
 
         self::assertFalse((new User($authentication, $authorization))->isAdministrator());
+    }
+
+    public function testIsAttendeeReturnsTrueWhenHasRole()
+    {
+        /** @var AuthenticationServiceInterface|\PHPUnit_Framework_MockObject_MockObject $authentication */
+        $authentication = $this->createMock(AuthenticationServiceInterface::class);
+
+        /** @var AuthorizationServiceInterface|\PHPUnit_Framework_MockObject_MockObject $authorization */
+        $authorization = $this->createMock(AuthorizationServiceInterface::class);
+        $authorization ->expects(self::once())
+            ->method('hasRole')
+            ->with(self::isInstanceOf(AttendeeRole::class))
+            ->willReturn(true);
+
+        self::assertTrue((new User($authentication, $authorization))->isAttendee());
+    }
+
+    public function testIsAttendeeReturnsFalseWhenDoesNotHaveRole()
+    {
+        /** @var AuthenticationServiceInterface|\PHPUnit_Framework_MockObject_MockObject $authentication */
+        $authentication = $this->createMock(AuthenticationServiceInterface::class);
+
+        /** @var AuthorizationServiceInterface|\PHPUnit_Framework_MockObject_MockObject $authorization */
+        $authorization = $this->createMock(AuthorizationServiceInterface::class);
+        $authorization ->expects(self::once())
+            ->method('hasRole')
+            ->with(self::isInstanceOf(AttendeeRole::class))
+            ->willReturn(false);
+
+        self::assertFalse((new User($authentication, $authorization))->isAttendee());
+    }
+
+    public function testGetReturnsUserFromAuthenticationService()
+    {
+        $user = UserEntity::new('foo@bar.com', new PhpPasswordHash(), 'correct horse battery staple');
+
+        /** @var AuthenticationServiceInterface|\PHPUnit_Framework_MockObject_MockObject $authentication */
+        $authentication = $this->createMock(AuthenticationServiceInterface::class);
+        $authentication->expects(self::once())->method('getIdentity')->willReturn($user);
+
+        /** @var AuthorizationServiceInterface|\PHPUnit_Framework_MockObject_MockObject $authorization */
+        $authorization = $this->createMock(AuthorizationServiceInterface::class);
+
+        self::assertSame($user, (new User($authentication, $authorization))->get());
     }
 }

--- a/test/AppTest/View/Helper/UserTest.php
+++ b/test/AppTest/View/Helper/UserTest.php
@@ -102,7 +102,7 @@ class UserTest extends \PHPUnit_Framework_TestCase
 
     public function testGetReturnsUserFromAuthenticationService()
     {
-        $user = UserEntity::new('foo@bar.com', new PhpPasswordHash(), 'correct horse battery staple');
+        $user = UserEntity::new('foo@bar.com', 'My Name', new PhpPasswordHash(), 'correct horse battery staple');
 
         /** @var AuthenticationServiceInterface|\PHPUnit_Framework_MockObject_MockObject $authentication */
         $authentication = $this->createMock(AuthenticationServiceInterface::class);


### PR DESCRIPTION
Fixes #102 

Last part of this task, so now users can:

 * Register a new user (has reCAPTCHA to try avoiding spam)
 * Login as a user
 * Mark as attending or not

The front end isn't particularly glorious, but it does the job *shrug*

Note: the features are intentionally not "exposed"; they're there, but mainly so we can try it out before we migrate fully to our own system. Also I'd like to have other auth types set up first (e.g. Twitter #144/Github #121/FB #145)