### PR TITLE
Allow dates for next year when creating talks

### DIFF
--- a/src/App/Form/Account/TalkForm.php
+++ b/src/App/Form/Account/TalkForm.php
@@ -30,6 +30,7 @@ class TalkForm extends Form implements InputFilterProviderInterface
         $this->add(
             (new DateTimeSelect('time'))
                 ->setShouldShowSeconds(false)
+                ->setMaxYear(date('Y') + 1)
                 ->setLabel('Start Time')
         );
 


### PR DESCRIPTION
I was just trying to modify the tests to check for this, but realised that the validation does not care what date it is!