### PR TITLE
Allow talk abstract to be saved without a speaker

### DIFF
--- a/src/App/Action/Account/Talk/AddTalkAction.php
+++ b/src/App/Action/Account/Talk/AddTalkAction.php
@@ -92,7 +92,8 @@ final class AddTalkAction implements MiddlewareInterface
                         $talk = Talk::fromTitle(
                             $meetup,
                             new \DateTimeImmutable($data['time']),
-                            $data['title']
+                            $data['title'],
+                            $data['abstract']
                         );
                     }
                     $this->entityManager->persist($talk);

--- a/src/App/Entity/Talk.php
+++ b/src/App/Entity/Talk.php
@@ -63,12 +63,16 @@ use Ramsey\Uuid\Uuid;
         $this->id = Uuid::uuid4();
     }
 
-    public static function fromTitle(Meetup $meetup, DateTimeImmutable $time, string $title) : self
+    public static function fromTitle(Meetup $meetup, DateTimeImmutable $time, string $title, string $abstract) : self
     {
         $talk = new self();
         $talk->meetup = $meetup;
         $talk->time = $time;
         $talk->title = $title;
+        $talk->abstract = $abstract;
+        if ($talk->abstract === '') {
+            $talk->abstract = null;
+        }
         return $talk;
     }
 

--- a/test/AppTest/Action/Account/Talk/DeleteTalkActionTest.php
+++ b/test/AppTest/Action/Account/Talk/DeleteTalkActionTest.php
@@ -23,7 +23,7 @@ final class DeleteTalkActionTest extends \PHPUnit_Framework_TestCase
         $meetup = $this->createMock(Meetup::class);
         $meetup->expects(self::any())->method('getId')->willReturn(Uuid::uuid4());
 
-        $talkToDelete = Talk::fromTitle($meetup, new \DateTimeImmutable(), 'The Talk Title');
+        $talkToDelete = Talk::fromTitle($meetup, new \DateTimeImmutable(), 'The Talk Title', '');
 
         $entityManager = $this->createMock(EntityManagerInterface::class);
         $entityManager->expects(self::once())->method('transactional')->willReturnCallback('call_user_func');

--- a/test/AppTest/Entity/TalkTest.php
+++ b/test/AppTest/Entity/TalkTest.php
@@ -18,7 +18,7 @@ class TalkTest extends \PHPUnit_Framework_TestCase
         $meetup = $this->createMock(Meetup::class);
         $time = new \DateTimeImmutable('2016-12-31 23:59:59');
 
-        $talk = Talk::fromTitle($meetup, $time, 'Some thing');
+        $talk = Talk::fromTitle($meetup, $time, 'Some thing', '');
 
         self::assertTrue(Uuid::isValid($talk->getId()));
         self::assertSame($meetup, $talk->getMeetup());
@@ -26,6 +26,22 @@ class TalkTest extends \PHPUnit_Framework_TestCase
         self::assertSame('Some thing', $talk->getTitle());
         self::assertNull($talk->getSpeaker());
         self::assertNull($talk->getAbstract());
+        self::assertNull($talk->getYoutubeId());
+    }
+
+    public function testFromTitleWithAbstract()
+    {
+        $meetup = $this->createMock(Meetup::class);
+        $time = new \DateTimeImmutable('2016-12-31 23:59:59');
+
+        $talk = Talk::fromTitle($meetup, $time, 'Some thing', 'Abstract about some thing');
+
+        self::assertTrue(Uuid::isValid($talk->getId()));
+        self::assertSame($meetup, $talk->getMeetup());
+        self::assertSame('2016-12-31 23:59:59', $talk->getTime()->format('Y-m-d H:i:s'));
+        self::assertSame('Some thing', $talk->getTitle());
+        self::assertNull($talk->getSpeaker());
+        self::assertSame('Abstract about some thing', $talk->getAbstract());
         self::assertNull($talk->getYoutubeId());
     }
 


### PR DESCRIPTION
This happens anyway if you edit the talk after saving :)