### PR TITLE
Removed company information since the CIC is dissolved

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2012-2016 PHP Hampshire CIC
+Copyright (c) 2012-2019 PHP Hampshire
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/templates/layout/footer.phtml
+++ b/templates/layout/footer.phtml
@@ -11,8 +11,7 @@
             <a href="<?= $this->escapeHtmlAttr($this->url('code-of-conduct')); ?>" >Code of Conduct</a>
             | <a href="<?= $this->escapeHtmlAttr($this->url('team')); ?>" >The Team</a>
         </p>
-        <p class="details">&copy; <?php echo date('Y'); ?> PHP Hampshire CIC. All website source code available under <a href="http://opensource.org/licenses/MIT">MIT license</a> from <a href="https://github.com/phphants/phph-site">PHP Hampshire GitHub</a>.</p>
-        <p class="details">PHP Hampshire CIC is registered in England and Wales, company number 09312297. VAT registered, number 226 583 594</p>
+        <p class="details">&copy; <?php echo date('Y'); ?> PHP Hampshire. All website source code available under <a href="http://opensource.org/licenses/MIT">MIT license</a> from <a href="https://github.com/phphants/phph-site">PHP Hampshire GitHub</a>.</p>
     </div>
 </footer>
 


### PR DESCRIPTION
PHP Hampshire CIC is dissolved as of today, so copyright and footer needs updating.